### PR TITLE
Getter for name_tag and plural

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,6 +393,12 @@ pub fn straitjacket(attr: TokenStream, item: TokenStream) -> TokenStream {
             #plural_snake: Vec<#name_tag>,
         }
 
+        impl #plural {
+            pub fn get_inner(&self) -> &Vec<#name_tag> {
+                &self.#plural_snake
+            }
+        }
+
         impl From<Vec<#name>> for #plural {
             fn from(mrvec: Vec<#name>) -> Self {
                 #plural {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,6 +385,11 @@ pub fn straitjacket(attr: TokenStream, item: TokenStream) -> TokenStream {
                 let #name_tag::Tag(inner) = self;
                 inner
             }
+
+            pub fn get_inner(&self) -> &#name_and_metadata {
+                let #name_tag::Tag(inner) = self;
+                inner
+            }
         }
 
         #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
For `#name_tag`, into_inner() is sometimes not usable because you need ownership to convert into `#name_and_metadata` unless you clone the struct implementing. Hence, `get_inner` is added to get the shared reference.

For `#plural`, it had no way to get the inner vector, so that's why I added a getter for it too.